### PR TITLE
feat: add restore endpoint for soft-deleted prompts

### DIFF
--- a/src/core/openapi.rs
+++ b/src/core/openapi.rs
@@ -82,6 +82,7 @@ use crate::shared::types::{ApiResponse, Meta};
         prompts_handlers::prompt_handler::list_prompts,
         prompts_handlers::prompt_handler::update_prompt,
         prompts_handlers::prompt_handler::delete_prompt,
+        prompts_handlers::prompt_handler::restore_prompt,
         // Admin
         admin_handlers::list_expectations,
         admin_handlers::get_expectation,

--- a/src/features/prompts/handlers/mod.rs
+++ b/src/features/prompts/handlers/mod.rs
@@ -1,3 +1,5 @@
 pub mod prompt_handler;
 
-pub use prompt_handler::{create_prompt, delete_prompt, get_prompt, list_prompts, update_prompt};
+pub use prompt_handler::{
+    create_prompt, delete_prompt, get_prompt, list_prompts, restore_prompt, update_prompt,
+};

--- a/src/features/prompts/handlers/prompt_handler.rs
+++ b/src/features/prompts/handlers/prompt_handler.rs
@@ -124,6 +124,34 @@ pub async fn update_prompt(
     Ok(Json(ApiResponse::success(Some(prompt), None, None)))
 }
 
+/// Restore a soft-deleted prompt (super admin only)
+#[utoipa::path(
+    post,
+    path = "/api/admin/prompts/{id}/restore",
+    params(
+        ("id" = Uuid, Path, description = "Prompt ID")
+    ),
+    responses(
+        (status = 200, description = "Prompt restored successfully", body = ApiResponse<PromptResponseDto>),
+        (status = 400, description = "Prompt is already active"),
+        (status = 404, description = "Prompt not found"),
+        (status = 409, description = "Active prompt with same key already exists"),
+        (status = 403, description = "Forbidden - super admin only")
+    ),
+    tag = "prompts",
+    security(
+        ("bearer_auth" = [])
+    )
+)]
+pub async fn restore_prompt(
+    RequireSuperAdmin(_user): RequireSuperAdmin,
+    State(service): State<Arc<PromptService>>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<ApiResponse<PromptResponseDto>>> {
+    let prompt = service.restore(id).await?;
+    Ok(Json(ApiResponse::success(Some(prompt), None, None)))
+}
+
 /// Delete a prompt (soft delete, super admin only)
 #[utoipa::path(
     delete,

--- a/src/features/prompts/routes.rs
+++ b/src/features/prompts/routes.rs
@@ -17,5 +17,9 @@ pub fn admin_routes(service: Arc<PromptService>) -> Router {
                 .put(handlers::update_prompt)
                 .delete(handlers::delete_prompt),
         )
+        .route(
+            "/api/admin/prompts/{id}/restore",
+            post(handlers::restore_prompt),
+        )
         .with_state(service)
 }


### PR DESCRIPTION
## Summary

- Add `POST /api/admin/prompts/:id/restore` endpoint for restoring soft-deleted prompts
- Validates key uniqueness before restore to prevent conflicts

## Changes

- **Service**: `restore()` method with conflict detection — checks if an active prompt with the same key exists before restoring
- **Handler**: `restore_prompt` with OpenAPI docs
- **Routes**: New `/api/admin/prompts/{id}/restore` route
- **OpenAPI**: Registered restore path

## Related Issue

Closes #6

## How to Test

1. Create a prompt, then delete it (soft delete)
2. Call `POST /api/admin/prompts/:id/restore` — should restore successfully
3. Create another prompt with the same key
4. Try restoring the old one — should return `409 Conflict`
5. Try restoring an already active prompt — should return `400 Bad Request`

## Checklist

- [x] Code compiles without errors (`cargo check`)
- [x] Clippy passes without warnings (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt -- --check`)
- [x] Tests pass (`cargo test`)
- [x] SQLx offline data is up to date (`cargo sqlx prepare`)
- [x] Migration files included (if database changes)
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)