### PR TITLE
feat: restrict prompt keys to backend-managed registry

### DIFF
--- a/.sqlx/query-701b90336ee7e560fb6a966efec5ef56e95011a5954c3d50e6fb90cdc16c039b.json
+++ b/.sqlx/query-701b90336ee7e560fb6a966efec5ef56e95011a5954c3d50e6fb90cdc16c039b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM prompts WHERE key = $1 AND is_active = true) as \"exists!\"",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "701b90336ee7e560fb6a966efec5ef56e95011a5954c3d50e6fb90cdc16c039b"
+}

--- a/.sqlx/query-dcfe4072c3592882971705adc191d547de43b7f9ec2ea7a5c63ae523dcee5a34.json
+++ b/.sqlx/query-dcfe4072c3592882971705adc191d547de43b7f9ec2ea7a5c63ae523dcee5a34.json
@@ -1,0 +1,88 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE prompts\n            SET is_active = true, version = version + 1, updated_at = NOW()\n            WHERE id = $1\n            RETURNING id, key, name, description, template_content,\n                      variables as \"variables: serde_json::Value\",\n                      version, is_active, created_at, updated_at, created_by, updated_by\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "template_content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "variables: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 6,
+        "name": "version",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 11,
+        "name": "updated_by",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "dcfe4072c3592882971705adc191d547de43b7f9ec2ea7a5c63ae523dcee5a34"
+}

--- a/src/core/openapi.rs
+++ b/src/core/openapi.rs
@@ -83,6 +83,7 @@ use crate::shared::types::{ApiResponse, Meta};
         prompts_handlers::prompt_handler::update_prompt,
         prompts_handlers::prompt_handler::delete_prompt,
         prompts_handlers::prompt_handler::restore_prompt,
+        prompts_handlers::prompt_handler::list_keys,
         // Admin
         admin_handlers::list_expectations,
         admin_handlers::get_expectation,
@@ -203,6 +204,8 @@ use crate::shared::types::{ApiResponse, Meta};
             prompts_dtos::PromptQueryParams,
             ApiResponse<prompts_dtos::PromptResponseDto>,
             ApiResponse<Vec<prompts_dtos::PromptResponseDto>>,
+            prompts_dtos::PromptKeyDefinition,
+            ApiResponse<Vec<prompts_dtos::PromptKeyDefinition>>,
             // Reports
             reports_models::ReportStatus,
             reports_models::ReportSeverity,

--- a/src/features/prompts/dtos/mod.rs
+++ b/src/features/prompts/dtos/mod.rs
@@ -1,3 +1,4 @@
 pub mod prompt_dto;
 
+pub use crate::features::prompts::registry::PromptKeyDefinition;
 pub use prompt_dto::{CreatePromptDto, PromptQueryParams, PromptResponseDto, UpdatePromptDto};

--- a/src/features/prompts/handlers/mod.rs
+++ b/src/features/prompts/handlers/mod.rs
@@ -1,5 +1,6 @@
 pub mod prompt_handler;
 
 pub use prompt_handler::{
-    create_prompt, delete_prompt, get_prompt, list_prompts, restore_prompt, update_prompt,
+    create_prompt, delete_prompt, get_prompt, list_keys, list_prompts, restore_prompt,
+    update_prompt,
 };

--- a/src/features/prompts/handlers/prompt_handler.rs
+++ b/src/features/prompts/handlers/prompt_handler.rs
@@ -9,6 +9,7 @@ use crate::features::auth::guards::RequireSuperAdmin;
 use crate::features::prompts::dtos::{
     CreatePromptDto, PromptQueryParams, PromptResponseDto, UpdatePromptDto,
 };
+use crate::features::prompts::registry::{get_all_prompt_keys, PromptKeyDefinition};
 use crate::features::prompts::services::PromptService;
 use crate::shared::types::{ApiResponse, Meta};
 
@@ -176,4 +177,24 @@ pub async fn delete_prompt(
 ) -> Result<Json<ApiResponse<()>>> {
     service.delete(id).await?;
     Ok(Json(ApiResponse::success(None, None, None)))
+}
+
+/// List all valid prompt keys from the registry (super admin only)
+#[utoipa::path(
+    get,
+    path = "/api/admin/prompts/keys",
+    responses(
+        (status = 200, description = "Prompt keys retrieved successfully", body = ApiResponse<Vec<PromptKeyDefinition>>),
+        (status = 403, description = "Forbidden - super admin only")
+    ),
+    tag = "prompts",
+    security(
+        ("bearer_auth" = [])
+    )
+)]
+pub async fn list_keys(
+    RequireSuperAdmin(_user): RequireSuperAdmin,
+) -> Result<Json<ApiResponse<Vec<PromptKeyDefinition>>>> {
+    let keys = get_all_prompt_keys();
+    Ok(Json(ApiResponse::success(Some(keys), None, None)))
 }

--- a/src/features/prompts/mod.rs
+++ b/src/features/prompts/mod.rs
@@ -1,6 +1,7 @@
 pub mod dtos;
 pub mod handlers;
 pub mod models;
+pub mod registry;
 pub mod routes;
 pub mod services;
 

--- a/src/features/prompts/registry.rs
+++ b/src/features/prompts/registry.rs
@@ -1,0 +1,33 @@
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// A prompt key definition from the backend-managed registry.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct PromptKeyDefinition {
+    /// The unique prompt key (e.g. "citizen_report_agent/system")
+    pub key: &'static str,
+    /// Human-readable description of what this prompt is used for
+    pub description: &'static str,
+}
+
+/// All valid prompt keys. This is the single source of truth.
+const PROMPT_KEY_REGISTRY: &[PromptKeyDefinition] = &[
+    PromptKeyDefinition {
+        key: "citizen_report_agent/system",
+        description: "System prompt for the citizen report AI agent",
+    },
+    PromptKeyDefinition {
+        key: "citizen_report_extraction/system",
+        description: "System prompt for extracting structured data from citizen reports",
+    },
+];
+
+/// Check whether the given key is in the registry.
+pub fn is_valid_prompt_key(key: &str) -> bool {
+    PROMPT_KEY_REGISTRY.iter().any(|def| def.key == key)
+}
+
+/// Return all registered prompt keys.
+pub fn get_all_prompt_keys() -> Vec<PromptKeyDefinition> {
+    PROMPT_KEY_REGISTRY.to_vec()
+}

--- a/src/features/prompts/routes.rs
+++ b/src/features/prompts/routes.rs
@@ -11,6 +11,7 @@ pub fn admin_routes(service: Arc<PromptService>) -> Router {
     Router::new()
         .route("/api/admin/prompts", post(handlers::create_prompt))
         .route("/api/admin/prompts", get(handlers::list_prompts))
+        .route("/api/admin/prompts/keys", get(handlers::list_keys))
         .route(
             "/api/admin/prompts/{id}",
             get(handlers::get_prompt)


### PR DESCRIPTION
## Summary
- Add a prompt key registry (`registry.rs`) as the single source of truth for valid prompt keys
- Add `GET /api/admin/prompts/keys` endpoint so the frontend can populate a dropdown instead of free-text input
- Validate prompt keys against the registry on creation, returning 400 with all valid keys listed if invalid

## Changes
| File | Change |
|------|--------|
| `src/features/prompts/registry.rs` | New — `PromptKeyDefinition` struct, `PROMPT_KEY_REGISTRY`, helper functions |
| `src/features/prompts/mod.rs` | Register `registry` module |
| `src/features/prompts/dtos/mod.rs` | Re-export `PromptKeyDefinition` for OpenAPI |
| `src/features/prompts/handlers/prompt_handler.rs` | Add `list_keys` handler |
| `src/features/prompts/handlers/mod.rs` | Export `list_keys` |
| `src/features/prompts/services/prompt_service.rs` | Key validation in `create()` |
| `src/features/prompts/routes.rs` | Register `/api/admin/prompts/keys` route |
| `src/core/openapi.rs` | Register path + schema |

## Test plan
- [x] `cargo check` — compiles clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all 45 tests pass
- [x] Manual: `GET /api/admin/prompts/keys` returns both registered keys
- [x] Manual: `POST /api/admin/prompts` with invalid key returns 400 with valid keys listed

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)